### PR TITLE
feat(query): add dot query support

### DIFF
--- a/lib/couchbase.js
+++ b/lib/couchbase.js
@@ -607,15 +607,19 @@ Couchbase.prototype._buildWhere = function(model, where) {
       // The value is not an array, fall back to regular fields
     }
     let p = props[key];
-    if (p == null) {
-      // Unknown property, ignore it
-      debug('Unknown property %s is skipped for model %s', key, model);
-      continue;
-    }
+    // if (p == null) {
+    //   // Unknown property, ignore it
+    //   debug('Unknown property %s is skipped for model %s', key, model);
+    //   continue;
+    // }
     // eslint-disable one-var
     let expression = where[key];
     let columnName = self.columnEscaped(model, key);
-    // eslint-enable one-var
+	
+	if (columnName.includes('.')) {
+		columnName = key;
+	}
+	// eslint-enable one-var
     if (expression === null || expression === undefined) {
       stmt.merge(columnName + ' IS NULL');
     } else if (expression === 'ismissing') {


### PR DESCRIPTION
The current version is not supporting querying embedded jsons
eg
```
designation: {
type: ''
}
```
I cant query by where designation.type = "Crew".
Added fix for this.